### PR TITLE
Fix `l*.c` by adding static definitions aggresively.

### DIFF
--- a/l1.c
+++ b/l1.c
@@ -38,36 +38,36 @@ typedef struct {
   long bi;
 } ENTRY;
 
-int n;
-LONG *neighborSets;
-ENTRY *hashTable;
-LONG all;
+static int n;
+static LONG *neighborSets;
+static ENTRY *hashTable;
+static LONG all;
 
-unsigned long trieUsed;
-NODE *trieRoots[L];
-NODE *trieArea;
+static unsigned long trieUsed;
+static NODE *trieRoots[L];
+static NODE *trieArea;
   
-long nb0;
-long nb;
-long nbMax;
-long trieMax;
-long nHash;
-long nbHidden;
-BLOCK *blocks;
+static long nb0;
+static long nb;
+static long nbMax;
+static long trieMax;
+static long nHash;
+static long nbHidden;
+static BLOCK *blocks;
   
-int targetWidth;
-int solution;
+static int targetWidth;
+static int solution;
 
-char dumpPrefix[65];
+static char dumpPrefix[65];
 
-struct timespec start;
+static struct timespec start;
 
-void L1extendBy(NODE *node, int v, LONG c, LONG neighb, LONG from);
-int L1bitCount(LONG s);
-void L1printSet(LONG s);
-void L1dumpTrie(NODE *node, int x);
+static void L1extendBy(NODE *node, int v, LONG c, LONG neighb, LONG from);
+static int L1bitCount(LONG s);
+static void L1printSet(LONG s);
+static void L1dumpTrie(NODE *node, int x);
 
-void L1allocate() {
+static void L1allocate() {
   nbMax = NB_MAX;
   long* trial; 
   while (1) {
@@ -94,7 +94,7 @@ void L1allocate() {
 #endif
 }
 
-void L1deallocate() {
+static void L1deallocate() {
   free(hashTable);
   free(trieArea);
   free(blocks);
@@ -103,7 +103,7 @@ void L1deallocate() {
 #endif
 }
 
-NODE* L1newNode(int v, BLOCK* block, NODE* left, NODE* right) {
+static NODE* L1newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   if (trieUsed == trieMax) {
     fprintf(stderr, "Trie area exhausted\n");
     exit(1);
@@ -116,7 +116,7 @@ NODE* L1newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   return &trieArea[trieUsed - 1];
 }
   
-void L1clear() {
+static void L1clear() {
   nb0 = 0;
   nb = 0;
   nbHidden = 0;
@@ -128,7 +128,7 @@ void L1clear() {
   memset(hashTable, 0, nHash * sizeof(ENTRY));
 }
 
-long L1getHash(LONG component) {
+static long L1getHash(LONG component) {
   unsigned long h = (unsigned long) (component % nHash);
   while (hashTable[h].key != 0) {
     if (hashTable[h].key == component) {
@@ -139,7 +139,7 @@ long L1getHash(LONG component) {
   return -1;
 }
   
-void L1putHash(LONG component, int bi) {
+static void L1putHash(LONG component, int bi) {
   unsigned long h = (unsigned long) (component % nHash);
   while (hashTable[h].key != 0) {
     if (hashTable[h].key == component) {
@@ -152,7 +152,7 @@ void L1putHash(LONG component, int bi) {
   hashTable[h].bi = bi;
 }
   
-LONG L1closedNeighbor(LONG c) {
+static LONG L1closedNeighbor(LONG c) {
   LONG cnb = c;
   for (int v = 0; v < n; v++) {
     if ((c & (1llu << v)) != 0) {
@@ -162,7 +162,7 @@ LONG L1closedNeighbor(LONG c) {
   return cnb;
 }
   
-LONG L1saturate(LONG c) {
+static LONG L1saturate(LONG c) {
   LONG cnb = L1closedNeighbor(c);
   LONG neighb = cnb & ~c;
   for (int v = 0; v < n; v++) {
@@ -176,7 +176,7 @@ LONG L1saturate(LONG c) {
   return c;
 }
 
-void L1addHiddenBlock(LONG component, LONG neighbors, LONG delta) {
+static void L1addHiddenBlock(LONG component, LONG neighbors, LONG delta) {
   long b = L1getHash(component);
   if (b >= 0) {
     return;
@@ -193,7 +193,7 @@ void L1addHiddenBlock(LONG component, LONG neighbors, LONG delta) {
   L1putHash(component, nbMax - nbHidden);
 }
 
-void L1registerBlock0(LONG component, LONG neighbors, LONG delta) {  
+static void L1registerBlock0(LONG component, LONG neighbors, LONG delta) {  
   if (L1getHash(component) >= 0) {
     return;
   }
@@ -231,7 +231,7 @@ void L1registerBlock0(LONG component, LONG neighbors, LONG delta) {
   #endif
 }
 
-void L1registerForVertex(int v, BLOCK *block) {
+static void L1registerForVertex(int v, BLOCK *block) {
 #ifdef DEBUG
   printf("L1registerForVertex %d:", v);
   L1printSet(block->component);
@@ -267,7 +267,7 @@ void L1registerForVertex(int v, BLOCK *block) {
   p->block = block;
 }
 
-void L1registerBlock(LONG component, LONG delta) {
+static void L1registerBlock(LONG component, LONG delta) {
 #ifdef TRACE
   printf("registering ");
   L1printSet(component);
@@ -297,7 +297,7 @@ void L1registerBlock(LONG component, LONG delta) {
   L1registerBlock0(component, neighb, delta);
 }
 
-void L1process(BLOCK *b) {
+static void L1process(BLOCK *b) {
   for (int v = 0; v < n; v++) {
     if ((b->neighbors & (1llu << v)) != 0) {
       L1registerForVertex(v, b);
@@ -322,7 +322,7 @@ void L1process(BLOCK *b) {
   }
 }
 
-int L1anAbsorbable(LONG vertices, LONG neighbors) {
+static int L1anAbsorbable(LONG vertices, LONG neighbors) {
   for (int v = 0; v < n; v++) {
     if ((neighbors & (1llu << v)) !=0 &&
         neighborSets[v] & ~(vertices | neighbors) == 0) {
@@ -332,7 +332,7 @@ int L1anAbsorbable(LONG vertices, LONG neighbors) {
   return -1;
 }
 
-void L1extendBy(NODE* node, int v, LONG c, LONG neighb, LONG from) {
+static void L1extendBy(NODE* node, int v, LONG c, LONG neighb, LONG from) {
 #ifdef TRACE
   printf("%d:%d,", v, node->v);
   L1printSet(c);
@@ -400,7 +400,7 @@ void L1extendBy(NODE* node, int v, LONG c, LONG neighb, LONG from) {
   }
 }
 
-void L1decompose() {
+static void L1decompose() {
 #ifdef VERBOSE
   printf("decomose enter\n");
 #endif
@@ -446,7 +446,7 @@ void L1decompose() {
 #endif
 }
 
-int L1bitCount(LONG s) {
+static int L1bitCount(LONG s) {
   int k = 0;
   for (int i = 0; i < n; i++) {
     if ((s & (1llu << i)) != 0) {
@@ -456,7 +456,7 @@ int L1bitCount(LONG s) {
   return k;
 }
  
-void L1printSet(LONG s) {
+static void L1printSet(LONG s) {
   for (int k = n - 1; k >= 0; k--) {
     if ((s & (1llu << k)) != 0) {
       putchar('1');
@@ -467,7 +467,7 @@ void L1printSet(LONG s) {
   }
 }
 
-void L1dumpTrie(NODE* node, int x) {
+static void L1dumpTrie(NODE* node, int x) {
   if (node == NULL) {
     return;
   }
@@ -496,7 +496,7 @@ void L1dumpTrie(NODE* node, int x) {
   }
 }
 
-BAG L1makeBag(LONG s) {
+static BAG L1makeBag(LONG s) {
   BAG bag;
   bag.nv = L1bitCount(s);
   bag.vertices = (int*) malloc(sizeof(int) * bag.nv);
@@ -509,7 +509,7 @@ BAG L1makeBag(LONG s) {
   return bag;
 }
 
-int L1addBag(LONG s, TD* td) {
+static int L1addBag(LONG s, TD* td) {
   int k = td->nBag;
   if (k == n) {
     fprintf(stderr, "too many bags\n");
@@ -520,7 +520,7 @@ int L1addBag(LONG s, TD* td) {
   return k;
 }
 
-void L1addTDEdge(int k, int j, TD* td) {
+static void L1addTDEdge(int k, int j, TD* td) {
   int i = td->nEdge;
   if (i == n) {
     fprintf(stderr, "too many decomposition edges\n");
@@ -531,7 +531,7 @@ void L1addTDEdge(int k, int j, TD* td) {
   (td->nEdge)++;
 }
 
-int L1getComponents(LONG vertices, LONG components[]) {
+static int L1getComponents(LONG vertices, LONG components[]) {
   int p = 0;
   LONG vs = vertices;
   for (int v = 0; v < n; v++) {
@@ -557,7 +557,7 @@ int L1getComponents(LONG vertices, LONG components[]) {
   return p;
 }
 
-BLOCK L1getBlock(LONG c) {
+static BLOCK L1getBlock(LONG c) {
   long bi = L1getHash(c);
   if (bi < 0) {
     fprintf(stderr, "block not in hash unexpectedly");
@@ -567,7 +567,7 @@ BLOCK L1getBlock(LONG c) {
 }
 
 
-int L1toTD(BLOCK block, TD* td) {
+static int L1toTD(BLOCK block, TD* td) {
   if (L1bitCount(block.component) + L1bitCount(block.neighbors)
       <= targetWidth + 1) {
     return L1addBag(block.component | block.neighbors, td);

--- a/l16.c
+++ b/l16.c
@@ -40,35 +40,35 @@ typedef struct {
   long bi;
 } ENTRY;
 
-int n;
-BSET *neighborSets;
-ENTRY *hashTable;
-BSET all;
-BSET empty;
+static int n;
+static BSET *neighborSets;
+static ENTRY *hashTable;
+static BSET all;
+static BSET empty;
 
-unsigned long trieUsed;
-NODE *trieRoots[L];
-NODE *trieArea;
+static unsigned long trieUsed;
+static NODE *trieRoots[L];
+static NODE *trieArea;
 
-long nb0;
-long nb;
-long nbMax;
-long trieMax;
-long nHash;
-long nbHidden;
-BLOCK *blocks;
+static long nb0;
+static long nb;
+static long nbMax;
+static long trieMax;
+static long nHash;
+static long nbHidden;
+static BLOCK *blocks;
 
-int targetWidth;
-int solution;
+static int targetWidth;
+static int solution;
 
-char dumpPrefix[L];
+static char dumpPrefix[L];
 
-struct timespec start;
+static struct timespec start;
 
-void L16extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L16extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L16printSet(BSET s);
-void L16dumpTrie(NODE *node, int x);
+static void L16extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L16extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L16printSet(BSET s);
+static void L16dumpTrie(NODE *node, int x);
 
 static inline BSET L16emptySet() {
   BSET s;
@@ -212,7 +212,7 @@ static inline unsigned long L16hash(BSET s) {
   return h;
 }
 
-void L16allocate() {
+static void L16allocate() {
   nbMax = NB_MAX;
   long* trial; 
   while (1) {
@@ -239,7 +239,7 @@ void L16allocate() {
 #endif
 }
 
-void L16deallocate() {
+static void L16deallocate() {
   free(hashTable);
   free(trieArea);
   free(blocks);
@@ -248,7 +248,7 @@ void L16deallocate() {
 #endif
 }
 
-NODE* L16newNode(int v, BLOCK* block, NODE* left, NODE* right) {
+static NODE* L16newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   if (trieUsed == trieMax) {
     fprintf(stderr, "Trie area exhausted\n");
     exit(1);
@@ -261,7 +261,7 @@ NODE* L16newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   return &trieArea[trieUsed - 1];
 }
 
-void L16clear() {
+static void L16clear() {
   nb0 = 0;
   nb = 0;
   nbHidden = 0;
@@ -273,7 +273,7 @@ void L16clear() {
   memset(hashTable, 0, nHash * sizeof(ENTRY));
 }
 
-long L16getHash(BSET component) {
+static long L16getHash(BSET component) {
   unsigned long h = L16hash(component);
   while (!L16equals(hashTable[h].key, empty)) {
     if (L16equals(hashTable[h].key, component)) {
@@ -284,7 +284,7 @@ long L16getHash(BSET component) {
   return -1;
 }
 
-void L16putHash(BSET component, int bi) {
+static void L16putHash(BSET component, int bi) {
   unsigned long h = L16hash(component);
   while (!L16equals(hashTable[h].key, empty)) {
     if (L16equals(hashTable[h].key, component)) {
@@ -297,7 +297,7 @@ void L16putHash(BSET component, int bi) {
   hashTable[h].bi = bi;
 }
 
-BSET L16closedNeighbor(BSET c) {
+static BSET L16closedNeighbor(BSET c) {
   BSET cnb = c;
   for (int v = 0; v < n; v++) {
     if (L16contains(c, v)) {
@@ -307,7 +307,7 @@ BSET L16closedNeighbor(BSET c) {
   return cnb;
 }
 
-BSET L16saturate(BSET c) {
+static BSET L16saturate(BSET c) {
   BSET cnb = L16closedNeighbor(c);
   BSET neighb = L16diff(cnb, c);
   for (int v = 0; v < n; v++) {
@@ -320,7 +320,7 @@ BSET L16saturate(BSET c) {
   return c;
 }
 
-void L16registerBlock0(BSET component, BSET neighbors, BSET delta) {  
+static void L16registerBlock0(BSET component, BSET neighbors, BSET delta) {  
   if (L16getHash(component) >= 0) {
     return;
   }
@@ -358,7 +358,7 @@ void L16registerBlock0(BSET component, BSET neighbors, BSET delta) {
   #endif
 }
 
-void L16addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
+static void L16addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   long b = L16getHash(component);
   if (b >= 0) {
     return;
@@ -375,7 +375,7 @@ void L16addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   L16putHash(component, nbMax - nbHidden);
 }
 
-void L16registerForVertex(int v, BLOCK *block) {
+static void L16registerForVertex(int v, BLOCK *block) {
 #ifdef DEBUG
   printf("registerForVertex %d:", v);
   L16printSet(block->component);
@@ -414,7 +414,7 @@ void L16registerForVertex(int v, BLOCK *block) {
   p->block = block;
 }
 
-void L16registerBlock(BSET component, BSET delta) {
+static void L16registerBlock(BSET component, BSET delta) {
 #ifdef TRACE
   printf("registering ");
   L16printSet(component);
@@ -445,7 +445,7 @@ void L16registerBlock(BSET component, BSET delta) {
   L16registerBlock0(component, neighb, delta);
 }
 
-void L16process(BLOCK *b) {
+static void L16process(BLOCK *b) {
   for (int v = 0; v < n; v++) {
     if (L16contains(b->neighbors, v)) {
       L16registerForVertex(v, b);
@@ -465,7 +465,7 @@ void L16process(BLOCK *b) {
 /*
       L16extendBy(trieRoots[v]->right, v, b->component,
           b->neighbors, empty);
-*/
+static */
       L16extendByIterative(trieRoots[v], v, b->component,
           b->neighbors, empty);
       if (solution >= 0) {
@@ -475,7 +475,7 @@ void L16process(BLOCK *b) {
   }
 }
 
-int L16anAbsorbable(BSET vertices, BSET neighbors) {
+static int L16anAbsorbable(BSET vertices, BSET neighbors) {
   for (int v = 0; v < n; v++) {
     if (L16contains(neighbors, v) &&
         L16isSubset(neighborSets[v], L16union_(vertices, neighbors))) {
@@ -485,7 +485,7 @@ int L16anAbsorbable(BSET vertices, BSET neighbors) {
   return -1;
 }
 
-void L16extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L16extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   /* an entry in the stack means that the righ child of the node is
      still to be processed 
   */
@@ -570,7 +570,7 @@ void L16extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   }
 }
 
-void L16extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L16extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 #ifdef TRACE
   printf("%d:%d,", v, node->v);
   L16printSet(c);
@@ -637,7 +637,7 @@ void L16extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 
 }
 
-void L16decompose() {
+static void L16decompose() {
 #ifdef VERBOSE
   printf("decomose enter\n");
 #endif
@@ -687,7 +687,7 @@ void L16decompose() {
 #endif
 }
 
-void L16printSet(BSET s) {
+static void L16printSet(BSET s) {
   for (int k = n - 1; k >= 0; k--) {
     if (L16contains(s, k)) {
       putchar('1');
@@ -698,7 +698,7 @@ void L16printSet(BSET s) {
   }
 }
 
-void L16dumpTrie(NODE* node, int x) {
+static void L16dumpTrie(NODE* node, int x) {
   if (node == NULL) {
     return;
   }
@@ -727,7 +727,7 @@ void L16dumpTrie(NODE* node, int x) {
   }
 }
 
-BAG L16makeBag(BSET s) {
+static BAG L16makeBag(BSET s) {
   BAG bag;
   bag.nv = L16bitCount(s);
   bag.vertices = (int*) malloc(sizeof(int) * bag.nv);
@@ -740,7 +740,7 @@ BAG L16makeBag(BSET s) {
   return bag;
 }
 
-int L16addBag(BSET s, TD* td) {
+static int L16addBag(BSET s, TD* td) {
   int k = td->nBag;
   if (k == n) {
     fprintf(stderr, "too many bags\n");
@@ -751,7 +751,7 @@ int L16addBag(BSET s, TD* td) {
   return k;
 }
 
-void L16addTDEdge(int k, int j, TD* td) {
+static void L16addTDEdge(int k, int j, TD* td) {
   int i = td->nEdge;
   if (i == n) {
     fprintf(stderr, "too many decomposition edges\n");
@@ -762,7 +762,7 @@ void L16addTDEdge(int k, int j, TD* td) {
   (td->nEdge)++;
 }
 
-int L16getComponents(BSET vertices, BSET components[]) {
+static int L16getComponents(BSET vertices, BSET components[]) {
   int p = 0;
   BSET vs = vertices;
   for (int v = 0; v < n; v++) {
@@ -790,7 +790,7 @@ int L16getComponents(BSET vertices, BSET components[]) {
   return p;
 }
 
-BLOCK* L16getBlock(BSET c) {
+static BLOCK* L16getBlock(BSET c) {
   long bi = L16getHash(c);
   if (bi < 0) {
     fprintf(stderr, "block not in hash unexpectedly");
@@ -800,7 +800,7 @@ BLOCK* L16getBlock(BSET c) {
 }
 
 
-int L16toTD(BLOCK* block, TD* td) {
+static int L16toTD(BLOCK* block, TD* td) {
   BLOCK* bStack[n];
   int aStack[n];
   BSET components[n];

--- a/l2.c
+++ b/l2.c
@@ -41,35 +41,35 @@ typedef struct {
   long bi;
 } ENTRY;
 
-int n;
-BSET *neighborSets;
-ENTRY *hashTable;
-BSET all;
-BSET empty;
+static int n;
+static BSET *neighborSets;
+static ENTRY *hashTable;
+static BSET all;
+static BSET empty;
 
-unsigned long trieUsed;
-NODE *trieRoots[L];
-NODE *trieArea;
+static unsigned long trieUsed;
+static NODE *trieRoots[L];
+static NODE *trieArea;
 
-long nb0;
-long nb;
-long nbMax;
-long trieMax;
-long nHash;
-long nbHidden;
-BLOCK *blocks;
+static long nb0;
+static long nb;
+static long nbMax;
+static long trieMax;
+static long nHash;
+static long nbHidden;
+static BLOCK *blocks;
 
-int targetWidth;
-int solution;
+static int targetWidth;
+static int solution;
 
-char dumpPrefix[L];
+static char dumpPrefix[L];
 
-struct timespec start;
+static struct timespec start;
 
-void L2extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L2extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L2printSet(BSET s);
-void L2dumpTrie(NODE *node, int x);
+static void L2extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L2extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L2printSet(BSET s);
+static void L2dumpTrie(NODE *node, int x);
 
 static inline BSET L2emptySet() {
   BSET s;
@@ -213,7 +213,7 @@ static inline unsigned long L2hash(BSET s) {
   return h;
 }
 
-void L2allocate() {
+static void L2allocate() {
   nbMax = NB_MAX;
   long* trial; 
   while (1) {
@@ -240,7 +240,7 @@ void L2allocate() {
 #endif
 }
 
-void L2deallocate() {
+static void L2deallocate() {
   free(hashTable);
   free(trieArea);
   free(blocks);
@@ -249,7 +249,7 @@ void L2deallocate() {
 #endif
 }
 
-NODE* L2newNode(int v, BLOCK* block, NODE* left, NODE* right) {
+static NODE* L2newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   if (trieUsed == trieMax) {
     fprintf(stderr, "Trie area exhausted\n");
     exit(1);
@@ -262,7 +262,7 @@ NODE* L2newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   return &trieArea[trieUsed - 1];
 }
 
-void L2clear() {
+static void L2clear() {
   nb0 = 0;
   nb = 0;
   nbHidden = 0;
@@ -274,7 +274,7 @@ void L2clear() {
   memset(hashTable, 0, nHash * sizeof(ENTRY));
 }
 
-long L2getHash(BSET component) {
+static long L2getHash(BSET component) {
   unsigned long h = L2hash(component);
   while (!L2equals(hashTable[h].key, empty)) {
     if (L2equals(hashTable[h].key, component)) {
@@ -285,7 +285,7 @@ long L2getHash(BSET component) {
   return -1;
 }
 
-void L2putHash(BSET component, int bi) {
+static void L2putHash(BSET component, int bi) {
   unsigned long h = L2hash(component);
   while (!L2equals(hashTable[h].key, empty)) {
     if (L2equals(hashTable[h].key, component)) {
@@ -298,7 +298,7 @@ void L2putHash(BSET component, int bi) {
   hashTable[h].bi = bi;
 }
 
-BSET L2closedNeighbor(BSET c) {
+static BSET L2closedNeighbor(BSET c) {
   BSET cnb = c;
   for (int v = 0; v < n; v++) {
     if (L2contains(c, v)) {
@@ -308,7 +308,7 @@ BSET L2closedNeighbor(BSET c) {
   return cnb;
 }
 
-BSET L2saturate(BSET c) {
+static BSET L2saturate(BSET c) {
   BSET cnb = L2closedNeighbor(c);
   BSET neighb = L2diff(cnb, c);
   for (int v = 0; v < n; v++) {
@@ -321,7 +321,7 @@ BSET L2saturate(BSET c) {
   return c;
 }
 
-void L2registerBlock0(BSET component, BSET neighbors, BSET delta) {  
+static void L2registerBlock0(BSET component, BSET neighbors, BSET delta) {  
   if (L2getHash(component) >= 0) {
     return;
   }
@@ -359,7 +359,7 @@ void L2registerBlock0(BSET component, BSET neighbors, BSET delta) {
   #endif
 }
 
-void L2addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
+static void L2addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   long b = L2getHash(component);
   if (b >= 0) {
     return;
@@ -376,7 +376,7 @@ void L2addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   L2putHash(component, nbMax - nbHidden);
 }
 
-void L2registerForVertex(int v, BLOCK *block) {
+static void L2registerForVertex(int v, BLOCK *block) {
 #ifdef DEBUG
   printf("registerForVertex %d:", v);
   L2printSet(block->component);
@@ -415,7 +415,7 @@ void L2registerForVertex(int v, BLOCK *block) {
   p->block = block;
 }
 
-void L2registerBlock(BSET component, BSET delta) {
+static void L2registerBlock(BSET component, BSET delta) {
 #ifdef TRACE
   printf("registering ");
   L2printSet(component);
@@ -446,7 +446,7 @@ void L2registerBlock(BSET component, BSET delta) {
   L2registerBlock0(component, neighb, delta);
 }
 
-void L2process(BLOCK *b) {
+static void L2process(BLOCK *b) {
   for (int v = 0; v < n; v++) {
     if (L2contains(b->neighbors, v)) {
       L2registerForVertex(v, b);
@@ -466,7 +466,7 @@ void L2process(BLOCK *b) {
 /*
       L2extendBy(trieRoots[v]->right, v, b->component,
           b->neighbors, empty);
-*/
+static */
       L2extendByIterative(trieRoots[v], v, b->component,
           b->neighbors, empty);
       if (solution >= 0) {
@@ -476,7 +476,7 @@ void L2process(BLOCK *b) {
   }
 }
 
-int L2anAbsorbable(BSET vertices, BSET neighbors) {
+static int L2anAbsorbable(BSET vertices, BSET neighbors) {
   for (int v = 0; v < n; v++) {
     if (L2contains(neighbors, v) &&
         L2isSubset(neighborSets[v], L2union_(vertices, neighbors))) {
@@ -486,7 +486,7 @@ int L2anAbsorbable(BSET vertices, BSET neighbors) {
   return -1;
 }
 
-void L2extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L2extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   /* an entry in the stack means that the righ child of the node is
      still to be processed 
   */
@@ -571,7 +571,7 @@ void L2extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   }
 }
 
-void L2extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L2extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 #ifdef TRACE
   printf("%d:%d,", v, node->v);
   L2printSet(c);
@@ -638,7 +638,7 @@ void L2extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 
 }
 
-void L2decompose() {
+static void L2decompose() {
 #ifdef VERBOSE
   printf("decomose enter\n");
 #endif
@@ -688,7 +688,7 @@ void L2decompose() {
 #endif
 }
 
-void L2printSet(BSET s) {
+static void L2printSet(BSET s) {
   for (int k = n - 1; k >= 0; k--) {
     if (L2contains(s, k)) {
       putchar('1');
@@ -699,7 +699,7 @@ void L2printSet(BSET s) {
   }
 }
 
-void L2dumpTrie(NODE* node, int x) {
+static void L2dumpTrie(NODE* node, int x) {
   if (node == NULL) {
     return;
   }
@@ -728,7 +728,7 @@ void L2dumpTrie(NODE* node, int x) {
   }
 }
 
-BAG L2makeBag(BSET s) {
+static BAG L2makeBag(BSET s) {
   BAG bag;
   bag.nv = L2bitCount(s);
   bag.vertices = (int*) malloc(sizeof(int) * bag.nv);
@@ -741,7 +741,7 @@ BAG L2makeBag(BSET s) {
   return bag;
 }
 
-int L2addBag(BSET s, TD* td) {
+static int L2addBag(BSET s, TD* td) {
   int k = td->nBag;
   if (k == n) {
     fprintf(stderr, "too many bags\n");
@@ -752,7 +752,7 @@ int L2addBag(BSET s, TD* td) {
   return k;
 }
 
-void L2addTDEdge(int k, int j, TD* td) {
+static void L2addTDEdge(int k, int j, TD* td) {
   int i = td->nEdge;
   if (i == n) {
     fprintf(stderr, "too many decomposition edges\n");
@@ -763,7 +763,7 @@ void L2addTDEdge(int k, int j, TD* td) {
   (td->nEdge)++;
 }
 
-int L2getComponents(BSET vertices, BSET components[]) {
+static int L2getComponents(BSET vertices, BSET components[]) {
   int p = 0;
   BSET vs = vertices;
   for (int v = 0; v < n; v++) {
@@ -791,7 +791,7 @@ int L2getComponents(BSET vertices, BSET components[]) {
   return p;
 }
 
-BLOCK* L2getBlock(BSET c) {
+static BLOCK* L2getBlock(BSET c) {
   long bi = L2getHash(c);
   if (bi < 0) {
     fprintf(stderr, "block not in hash unexpectedly");
@@ -801,7 +801,7 @@ BLOCK* L2getBlock(BSET c) {
 }
 
 
-int L2toTD(BLOCK* block, TD* td) {
+static int L2toTD(BLOCK* block, TD* td) {
   BLOCK* bStack[n];
   int aStack[n];
   BSET components[n];

--- a/l4.c
+++ b/l4.c
@@ -41,35 +41,35 @@ typedef struct {
   long bi;
 } ENTRY;
 
-int n;
-BSET *neighborSets;
-ENTRY *hashTable;
-BSET all;
-BSET empty;
+static int n;
+static BSET *neighborSets;
+static ENTRY *hashTable;
+static BSET all;
+static BSET empty;
 
-unsigned long trieUsed;
-NODE *trieRoots[L];
-NODE *trieArea;
+static unsigned long trieUsed;
+static NODE *trieRoots[L];
+static NODE *trieArea;
 
-long nb0;
-long nb;
-long nbMax;
-long trieMax;
-long nHash;
-long nbHidden;
-BLOCK *blocks;
+static long nb0;
+static long nb;
+static long nbMax;
+static long trieMax;
+static long nHash;
+static long nbHidden;
+static BLOCK *blocks;
 
-int targetWidth;
-int solution;
+static int targetWidth;
+static int solution;
 
-char dumpPrefix[L];
+static char dumpPrefix[L];
 
-struct timespec start;
+static struct timespec start;
 
-void L4extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L4extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L4printSet(BSET s);
-void L4dumpTrie(NODE *node, int x);
+static void L4extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L4extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L4printSet(BSET s);
+static void L4dumpTrie(NODE *node, int x);
 
 static inline BSET L4emptySet() {
   BSET s;
@@ -213,7 +213,7 @@ static inline unsigned long L4hash(BSET s) {
   return h;
 }
 
-void L4allocate() {
+static void L4allocate() {
   nbMax = NB_MAX;
   long* trial; 
   while (1) {
@@ -240,7 +240,7 @@ void L4allocate() {
 #endif
 }
 
-void L4deallocate() {
+static void L4deallocate() {
   free(hashTable);
   free(trieArea);
   free(blocks);
@@ -249,7 +249,7 @@ void L4deallocate() {
 #endif
 }
 
-NODE* L4newNode(int v, BLOCK* block, NODE* left, NODE* right) {
+static NODE* L4newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   if (trieUsed == trieMax) {
     fprintf(stderr, "Trie area exhausted\n");
     exit(1);
@@ -262,7 +262,7 @@ NODE* L4newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   return &trieArea[trieUsed - 1];
 }
 
-void L4clear() {
+static void L4clear() {
   nb0 = 0;
   nb = 0;
   nbHidden = 0;
@@ -274,7 +274,7 @@ void L4clear() {
   memset(hashTable, 0, nHash * sizeof(ENTRY));
 }
 
-long L4getHash(BSET component) {
+static long L4getHash(BSET component) {
   unsigned long h = L4hash(component);
   while (!L4equals(hashTable[h].key, empty)) {
     if (L4equals(hashTable[h].key, component)) {
@@ -285,7 +285,7 @@ long L4getHash(BSET component) {
   return -1;
 }
 
-void L4putHash(BSET component, int bi) {
+static void L4putHash(BSET component, int bi) {
   unsigned long h = L4hash(component);
   while (!L4equals(hashTable[h].key, empty)) {
     if (L4equals(hashTable[h].key, component)) {
@@ -298,7 +298,7 @@ void L4putHash(BSET component, int bi) {
   hashTable[h].bi = bi;
 }
 
-BSET L4closedNeighbor(BSET c) {
+static BSET L4closedNeighbor(BSET c) {
   BSET cnb = c;
   for (int v = 0; v < n; v++) {
     if (L4contains(c, v)) {
@@ -308,7 +308,7 @@ BSET L4closedNeighbor(BSET c) {
   return cnb;
 }
 
-BSET L4saturate(BSET c) {
+static BSET L4saturate(BSET c) {
   BSET cnb = L4closedNeighbor(c);
   BSET neighb = L4diff(cnb, c);
   for (int v = 0; v < n; v++) {
@@ -321,7 +321,7 @@ BSET L4saturate(BSET c) {
   return c;
 }
 
-void L4registerBlock0(BSET component, BSET neighbors, BSET delta) {  
+static void L4registerBlock0(BSET component, BSET neighbors, BSET delta) {  
   if (L4getHash(component) >= 0) {
     return;
   }
@@ -359,7 +359,7 @@ void L4registerBlock0(BSET component, BSET neighbors, BSET delta) {
   #endif
 }
 
-void L4addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
+static void L4addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   long b = L4getHash(component);
   if (b >= 0) {
     return;
@@ -376,7 +376,7 @@ void L4addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   L4putHash(component, nbMax - nbHidden);
 }
 
-void L4registerForVertex(int v, BLOCK *block) {
+static void L4registerForVertex(int v, BLOCK *block) {
 #ifdef DEBUG
   printf("registerForVertex %d:", v);
   L4printSet(block->component);
@@ -415,7 +415,7 @@ void L4registerForVertex(int v, BLOCK *block) {
   p->block = block;
 }
 
-void L4registerBlock(BSET component, BSET delta) {
+static void L4registerBlock(BSET component, BSET delta) {
 #ifdef TRACE
   printf("registering ");
   L4printSet(component);
@@ -446,7 +446,7 @@ void L4registerBlock(BSET component, BSET delta) {
   L4registerBlock0(component, neighb, delta);
 }
 
-void L4process(BLOCK *b) {
+static void L4process(BLOCK *b) {
   for (int v = 0; v < n; v++) {
     if (L4contains(b->neighbors, v)) {
       L4registerForVertex(v, b);
@@ -466,7 +466,7 @@ void L4process(BLOCK *b) {
 /*
       L4extendBy(trieRoots[v]->right, v, b->component,
           b->neighbors, empty);
-*/
+static */
       L4extendByIterative(trieRoots[v], v, b->component,
           b->neighbors, empty);
       if (solution >= 0) {
@@ -476,7 +476,7 @@ void L4process(BLOCK *b) {
   }
 }
 
-int L4anAbsorbable(BSET vertices, BSET neighbors) {
+static int L4anAbsorbable(BSET vertices, BSET neighbors) {
   for (int v = 0; v < n; v++) {
     if (L4contains(neighbors, v) &&
         L4isSubset(neighborSets[v], L4union_(vertices, neighbors))) {
@@ -486,7 +486,7 @@ int L4anAbsorbable(BSET vertices, BSET neighbors) {
   return -1;
 }
 
-void L4extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L4extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   /* an entry in the stack means that the righ child of the node is
      still to be processed 
   */
@@ -571,7 +571,7 @@ void L4extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   }
 }
 
-void L4extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L4extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 #ifdef TRACE
   printf("%d:%d,", v, node->v);
   L4printSet(c);
@@ -638,7 +638,7 @@ void L4extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 
 }
 
-void L4decompose() {
+static void L4decompose() {
 #ifdef VERBOSE
   printf("decomose enter\n");
 #endif
@@ -688,7 +688,7 @@ void L4decompose() {
 #endif
 }
 
-void L4printSet(BSET s) {
+static void L4printSet(BSET s) {
   for (int k = n - 1; k >= 0; k--) {
     if (L4contains(s, k)) {
       putchar('1');
@@ -699,7 +699,7 @@ void L4printSet(BSET s) {
   }
 }
 
-void L4dumpTrie(NODE* node, int x) {
+static void L4dumpTrie(NODE* node, int x) {
   if (node == NULL) {
     return;
   }
@@ -728,7 +728,7 @@ void L4dumpTrie(NODE* node, int x) {
   }
 }
 
-BAG L4makeBag(BSET s) {
+static BAG L4makeBag(BSET s) {
   BAG bag;
   bag.nv = L4bitCount(s);
   bag.vertices = (int*) malloc(sizeof(int) * bag.nv);
@@ -741,7 +741,7 @@ BAG L4makeBag(BSET s) {
   return bag;
 }
 
-int L4addBag(BSET s, TD* td) {
+static int L4addBag(BSET s, TD* td) {
   int k = td->nBag;
   if (k == n) {
     fprintf(stderr, "too many bags\n");
@@ -752,7 +752,7 @@ int L4addBag(BSET s, TD* td) {
   return k;
 }
 
-void L4addTDEdge(int k, int j, TD* td) {
+static void L4addTDEdge(int k, int j, TD* td) {
   int i = td->nEdge;
   if (i == n) {
     fprintf(stderr, "too many decomposition edges\n");
@@ -763,7 +763,7 @@ void L4addTDEdge(int k, int j, TD* td) {
   (td->nEdge)++;
 }
 
-int L4getComponents(BSET vertices, BSET components[]) {
+static int L4getComponents(BSET vertices, BSET components[]) {
   int p = 0;
   BSET vs = vertices;
   for (int v = 0; v < n; v++) {
@@ -791,7 +791,7 @@ int L4getComponents(BSET vertices, BSET components[]) {
   return p;
 }
 
-BLOCK* L4getBlock(BSET c) {
+static BLOCK* L4getBlock(BSET c) {
   long bi = L4getHash(c);
   if (bi < 0) {
     fprintf(stderr, "block not in hash unexpectedly");
@@ -801,7 +801,7 @@ BLOCK* L4getBlock(BSET c) {
 }
 
 
-int L4toTD(BLOCK* block, TD* td) {
+static int L4toTD(BLOCK* block, TD* td) {
   BLOCK* bStack[n];
   int aStack[n];
   BSET components[n];

--- a/l64.c
+++ b/l64.c
@@ -40,35 +40,35 @@ typedef struct {
   long bi;
 } ENTRY;
 
-int n;
-BSET *neighborSets;
-ENTRY *hashTable;
-BSET all;
-BSET empty;
+static int n;
+static BSET *neighborSets;
+static ENTRY *hashTable;
+static BSET all;
+static BSET empty;
 
-unsigned long trieUsed;
-NODE *trieRoots[L];
-NODE *trieArea;
+static unsigned long trieUsed;
+static NODE *trieRoots[L];
+static NODE *trieArea;
 
-long nb0;
-long nb;
-long nbMax;
-long trieMax;
-long nHash;
-long nbHidden;
-BLOCK *blocks;
+static long nb0;
+static long nb;
+static long nbMax;
+static long trieMax;
+static long nHash;
+static long nbHidden;
+static BLOCK *blocks;
 
-int targetWidth;
-int solution;
+static int targetWidth;
+static int solution;
 
-char dumpPrefix[L];
+static char dumpPrefix[L];
 
-struct timespec start;
+static struct timespec start;
 
-void L64extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L64extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
-void L64printSet(BSET s);
-void L64dumpTrie(NODE *node, int x);
+static void L64extendBy(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L64extendByIterative(NODE *node, int v, BSET c, BSET neighb, BSET from);
+static void L64printSet(BSET s);
+static void L64dumpTrie(NODE *node, int x);
 
 static inline BSET L64emptySet() {
   BSET s;
@@ -212,7 +212,7 @@ static inline unsigned long L64hash(BSET s) {
   return h;
 }
 
-void L64allocate() {
+static void L64allocate() {
   nbMax = NB_MAX;
   long* trial; 
   while (1) {
@@ -239,7 +239,7 @@ void L64allocate() {
 #endif
 }
 
-void L64deallocate() {
+static void L64deallocate() {
   free(hashTable);
   free(trieArea);
   free(blocks);
@@ -248,7 +248,7 @@ void L64deallocate() {
 #endif
 }
 
-NODE* L64newNode(int v, BLOCK* block, NODE* left, NODE* right) {
+static NODE* L64newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   if (trieUsed == trieMax) {
     fprintf(stderr, "Trie area exhausted\n");
     exit(1);
@@ -261,7 +261,7 @@ NODE* L64newNode(int v, BLOCK* block, NODE* left, NODE* right) {
   return &trieArea[trieUsed - 1];
 }
 
-void L64clear() {
+static void L64clear() {
   nb0 = 0;
   nb = 0;
   nbHidden = 0;
@@ -273,7 +273,7 @@ void L64clear() {
   memset(hashTable, 0, nHash * sizeof(ENTRY));
 }
 
-long L64getHash(BSET component) {
+static long L64getHash(BSET component) {
   unsigned long h = L64hash(component);
   while (!L64equals(hashTable[h].key, empty)) {
     if (L64equals(hashTable[h].key, component)) {
@@ -284,7 +284,7 @@ long L64getHash(BSET component) {
   return -1;
 }
 
-void L64putHash(BSET component, int bi) {
+static void L64putHash(BSET component, int bi) {
   unsigned long h = L64hash(component);
   while (!L64equals(hashTable[h].key, empty)) {
     if (L64equals(hashTable[h].key, component)) {
@@ -297,7 +297,7 @@ void L64putHash(BSET component, int bi) {
   hashTable[h].bi = bi;
 }
 
-BSET L64closedNeighbor(BSET c) {
+static BSET L64closedNeighbor(BSET c) {
   BSET cnb = c;
   for (int v = 0; v < n; v++) {
     if (L64contains(c, v)) {
@@ -307,7 +307,7 @@ BSET L64closedNeighbor(BSET c) {
   return cnb;
 }
 
-BSET L64saturate(BSET c) {
+static BSET L64saturate(BSET c) {
   BSET cnb = L64closedNeighbor(c);
   BSET neighb = L64diff(cnb, c);
   for (int v = 0; v < n; v++) {
@@ -320,7 +320,7 @@ BSET L64saturate(BSET c) {
   return c;
 }
 
-void L64registerBlock0(BSET component, BSET neighbors, BSET delta) {  
+static void L64registerBlock0(BSET component, BSET neighbors, BSET delta) {  
   if (L64getHash(component) >= 0) {
     return;
   }
@@ -358,7 +358,7 @@ void L64registerBlock0(BSET component, BSET neighbors, BSET delta) {
   #endif
 }
 
-void L64addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
+static void L64addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   long b = L64getHash(component);
   if (b >= 0) {
     return;
@@ -375,7 +375,7 @@ void L64addHiddenBlock(BSET component, BSET neighbors, BSET delta) {
   L64putHash(component, nbMax - nbHidden);
 }
 
-void L64registerForVertex(int v, BLOCK *block) {
+static void L64registerForVertex(int v, BLOCK *block) {
 #ifdef DEBUG
   printf("registerForVertex %d:", v);
   L64printSet(block->component);
@@ -414,7 +414,7 @@ void L64registerForVertex(int v, BLOCK *block) {
   p->block = block;
 }
 
-void L64registerBlock(BSET component, BSET delta) {
+static void L64registerBlock(BSET component, BSET delta) {
 #ifdef TRACE
   printf("registering ");
   L64printSet(component);
@@ -445,7 +445,7 @@ void L64registerBlock(BSET component, BSET delta) {
   L64registerBlock0(component, neighb, delta);
 }
 
-void L64process(BLOCK *b) {
+static void L64process(BLOCK *b) {
   for (int v = 0; v < n; v++) {
     if (L64contains(b->neighbors, v)) {
       L64registerForVertex(v, b);
@@ -465,7 +465,7 @@ void L64process(BLOCK *b) {
 /*
       L64extendBy(trieRoots[v]->right, v, b->component,
           b->neighbors, empty);
-*/
+static */
       L64extendByIterative(trieRoots[v], v, b->component,
           b->neighbors, empty);
       if (solution >= 0) {
@@ -475,7 +475,7 @@ void L64process(BLOCK *b) {
   }
 }
 
-int L64anAbsorbable(BSET vertices, BSET neighbors) {
+static int L64anAbsorbable(BSET vertices, BSET neighbors) {
   for (int v = 0; v < n; v++) {
     if (L64contains(neighbors, v) &&
         L64isSubset(neighborSets[v], L64union_(vertices, neighbors))) {
@@ -485,7 +485,7 @@ int L64anAbsorbable(BSET vertices, BSET neighbors) {
   return -1;
 }
 
-void L64extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L64extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   /* an entry in the stack means that the righ child of the node is
      still to be processed 
   */
@@ -570,7 +570,7 @@ void L64extendByIterative(NODE* node, int v, BSET c, BSET neighb, BSET from) {
   }
 }
 
-void L64extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
+static void L64extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 #ifdef TRACE
   printf("%d:%d,", v, node->v);
   L64printSet(c);
@@ -637,7 +637,7 @@ void L64extendBy(NODE* node, int v, BSET c, BSET neighb, BSET from) {
 
 }
 
-void L64decompose() {
+static void L64decompose() {
 #ifdef VERBOSE
   printf("decomose enter\n");
 #endif
@@ -687,7 +687,7 @@ void L64decompose() {
 #endif
 }
 
-void L64printSet(BSET s) {
+static void L64printSet(BSET s) {
   for (int k = n - 1; k >= 0; k--) {
     if (L64contains(s, k)) {
       putchar('1');
@@ -698,7 +698,7 @@ void L64printSet(BSET s) {
   }
 }
 
-void L64dumpTrie(NODE* node, int x) {
+static void L64dumpTrie(NODE* node, int x) {
   if (node == NULL) {
     return;
   }
@@ -727,7 +727,7 @@ void L64dumpTrie(NODE* node, int x) {
   }
 }
 
-BAG L64makeBag(BSET s) {
+static BAG L64makeBag(BSET s) {
   BAG bag;
   bag.nv = L64bitCount(s);
   bag.vertices = (int*) malloc(sizeof(int) * bag.nv);
@@ -740,7 +740,7 @@ BAG L64makeBag(BSET s) {
   return bag;
 }
 
-int L64addBag(BSET s, TD* td) {
+static int L64addBag(BSET s, TD* td) {
   int k = td->nBag;
   if (k == n) {
     fprintf(stderr, "too many bags\n");
@@ -751,7 +751,7 @@ int L64addBag(BSET s, TD* td) {
   return k;
 }
 
-void L64addTDEdge(int k, int j, TD* td) {
+static void L64addTDEdge(int k, int j, TD* td) {
   int i = td->nEdge;
   if (i == n) {
     fprintf(stderr, "too many decomposition edges\n");
@@ -762,7 +762,7 @@ void L64addTDEdge(int k, int j, TD* td) {
   (td->nEdge)++;
 }
 
-int L64getComponents(BSET vertices, BSET components[]) {
+static int L64getComponents(BSET vertices, BSET components[]) {
   int p = 0;
   BSET vs = vertices;
   for (int v = 0; v < n; v++) {
@@ -790,7 +790,7 @@ int L64getComponents(BSET vertices, BSET components[]) {
   return p;
 }
 
-BLOCK* L64getBlock(BSET c) {
+static BLOCK* L64getBlock(BSET c) {
   long bi = L64getHash(c);
   if (bi < 0) {
     fprintf(stderr, "block not in hash unexpectedly");
@@ -800,7 +800,7 @@ BLOCK* L64getBlock(BSET c) {
 }
 
 
-int L64toTD(BLOCK* block, TD* td) {
+static int L64toTD(BLOCK* block, TD* td) {
   BLOCK* bStack[n];
   int aStack[n];
   BSET components[n];


### PR DESCRIPTION
Solves https://github.com/TCS-Meiji/treewidth-exact/issues/1

Changes by running in Python 3.10:

```
import sys
import glob
import os

def revise_manually(filename, skip_prefix, d=None):
    new_filename = f'{d}/{filename}'
    with open(filename) as f:
        with open(new_filename,'w') as nf:
            res = []
            for l in f.readlines():
                if any(l.startswith(p) for p in ['#', ' ', '\t', '/', '\n', 'typedef', '}', 'static']) :
                    print(l, end='', file = nf)
                elif any(l.startswith(p) for p in skip_prefix) :
                    print(l, end='', file = nf)
                else:
                    print('static '+l, end='', file = nf)
    return new_filename

def get_skip_static():
    res = []
    for h in glob.glob('*.h'):
        with open(h) as f:
            for l in f.readlines():
                if l.startswith('#'):
                    continue
                l = l.split('(')
                if len(l) > 1:
                    res.append(l[0])
    return res

if __name__ == "__main__":
    target_dir = 'new'
    os.mkdir(target_dir)
    skip_static = get_skip_static()
    for x in glob.glob('l*.c'):
        new_x = revise_manually(x, skip_prefix=skip_static, d=target_dir)
        os.replace(new_x, x)
    os.rmdir(target_dir)
```